### PR TITLE
Re-add license file that had been mistakenly deleted and update copyright

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Patrick Esser and Robin Rombach and Björn Ommer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE./

--- a/License.txt
+++ b/License.txt
@@ -1,3 +1,5 @@
+Copyright (c) 2022-2023 Imageomics
+
 Copyright (c) 2020 Patrick Esser and Robin Rombach and Björn Ommer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
The [original license file](https://github.com/CompVis/taming-transformers/blob/master/License.txt) from the repository from which this repo was forked was accidentally deleted in one of the earliest commits. This PR re-adds it.

Additionally, this repo has been edited significantly since that initial fork and the license is updated to add copyright from that point (a54b25cfc7b1463693295595ed6a6d47322cf2d3).